### PR TITLE
Lighter Github Action

### DIFF
--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: 'arm64,arm' # support AWS EC2 t4g
+          platforms: 'arm64' # support AWS EC2 t4g
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Configure AWS credentials

--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: 'arm64' # support AWS EC2 t4g
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v2
+      #   with:
+      #     platforms: 'arm64' # support AWS EC2 t4g
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Configure AWS credentials

--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v2
-      #   with:
-      #     platforms: 'arm64' # support AWS EC2 t4g
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64' # support AWS EC2 t4g
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Configure AWS credentials


### PR DESCRIPTION
쓰고 있는 AWS Graviton 인스턴스가 `arm64`라서 `arm64` 빌드만 해도 충분함.