### PR TITLE
Fix/opening hours logic

### DIFF
--- a/lib/opening_hours.ts
+++ b/lib/opening_hours.ts
@@ -25,10 +25,6 @@ export function isOnOpeningHours(
   start_time: string, // hh:mm
   end_time: string, // hh:mm
 ) {
-  console.log(opening_hours);
-  console.log(weekday);
-  console.log(start_time);
-  console.log(end_time);
   const openingHour = JSON.parse(opening_hours);
 
   if (openingHour['Everyday']) {

--- a/lib/opening_hours.ts
+++ b/lib/opening_hours.ts
@@ -37,8 +37,8 @@ export function isOnOpeningHours(
   const hours = openingHour[weekday].split(',');
 
   for (const hour of hours) {
-    // 다음과 같이 &가 있어 시간이 나눠지는 상황도 고려해야 함 "Sunday":"00:00-10:00 & 13:00~24:00"
-    const openTimesPerDay = hour.split('&');
+    // 다음과 같이 &가 있어 시간이 나눠지는 상황도 고려해야 함 "Sunday":"00:00-10:00 & 13:00-24:00"
+    const openTimesPerDay = hour.split(' & ');
     for (const openTime of openTimesPerDay) {
       const open_start = openTime.split('-')[0];
       const open_end = openTime.split('-')[1];

--- a/lib/opening_hours.ts
+++ b/lib/opening_hours.ts
@@ -25,6 +25,10 @@ export function isOnOpeningHours(
   start_time: string, // hh:mm
   end_time: string, // hh:mm
 ) {
+  console.log(opening_hours);
+  console.log(weekday);
+  console.log(start_time);
+  console.log(end_time);
   const openingHour = JSON.parse(opening_hours);
 
   if (openingHour['Everyday']) {
@@ -37,13 +41,17 @@ export function isOnOpeningHours(
   const hours = openingHour[weekday].split(',');
 
   for (const hour of hours) {
-    const open_start = hour.split('-')[0];
-    const open_end = hour.split('-')[1];
+    // 다음과 같이 &가 있어 시간이 나눠지는 상황도 고려해야 함 "Sunday":"00:00-10:00 & 13:00~24:00"
+    const openTimesPerDay = hour.split('&');
+    for (const openTime of openTimesPerDay) {
+      const open_start = openTime.split('-')[0];
+      const open_end = openTime.split('-')[1];
 
-    // 하나라도 range 내부에 포함된다면 예약 가능
-    const isInside = open_start <= start_time && end_time <= open_end;
-    if (isInside) {
-      return true;
+      // 하나라도 range 내부에 포함된다면 예약 가능
+      const isInside = open_start <= start_time && end_time <= open_end;
+      if (isInside) {
+        return true;
+      }
     }
   }
 


### PR DESCRIPTION
문제 상황: 대회의실 제한 시간이 아닌 시간에도 예약이 불가능하다고 뜨는 문제 발생
![image](https://github.com/user-attachments/assets/7be18995-93f6-4aeb-abb4-4eaaef7b0a54)

문제: 
1. 대회의실 두 번째 예약 가능 시간이 '-' 가 아닌 '~'로 나눠져 있어 '-'로 파싱하는 프론트 코드에서 시간을 나누지 못했음
![image](https://github.com/user-attachments/assets/0a3b9689-415a-4e77-80ae-f73c414c9bfe)

2. 코드 상에서 위 사진과 같이 하루에 예약 가능 시간이 한 타임이 아니라 여러 개인 경우를 고려하지 않고 있었음 

해결:
어드민 페이지에서 시간 나누는 부분을 '-'로 고쳤고, ' & '로 나눠진 복수 개의 예약 가능 시간들도 고려하게 변경했음
![image](https://github.com/user-attachments/assets/782909e0-2005-4c4b-9106-1b6966c0b059)

