### PR TITLE
Feat: Refresh expired token and ask same request again

### DIFF
--- a/lib/axios.instance.ts
+++ b/lib/axios.instance.ts
@@ -1,4 +1,11 @@
 import axios from 'axios';
+import {
+  refreshAccessToken,
+  getIsRefreshing,
+  setIsRefreshing,
+  addToFailedQueue,
+  processQueue,
+} from './refresh.utils';
 
 const next_env = process.env.NEXT_PUBLIC_ENV;
 
@@ -15,7 +22,7 @@ export const PoPoAxios = axios.create({
   baseURL: popoApiUrl as string,
 });
 
-// 엑세스 토큰 만료 시 리프레시 후 재시도 로직
+// 엑세스 토큰 만료 시 refresh 후 재시도 로직
 PoPoAxios.interceptors.response.use(
   (response) => response,
   async (error) => {
@@ -25,22 +32,32 @@ PoPoAxios.interceptors.response.use(
       error.response?.status === 401 &&
       // 백엔드에서 엑세스 토큰 만료 시 내려주는 에러 메시지
       error.response?.data?.error === 'AccessTokenExpired' &&
-      // 동일 요청 재시도를 방지하기 위함
       !originalRequest._retry
     ) {
-      try {
-        // refresh 요청
-        await refreshAccessToken();
+      if (getIsRefreshing()) {
+        // 이미 refresh 중이면 큐에 추가
+        return new Promise((resolve, reject) => {
+          addToFailedQueue(resolve, reject, originalRequest);
+        });
+      }
 
-        // 원래 요청 재시도
-        originalRequest._retry = true;
+      originalRequest._retry = true;
+      setIsRefreshing(true);
+
+      try {
+        // refresh 토큰 재발급
+        await refreshAccessToken();
+        processQueue(null);
         return PoPoAxios(originalRequest);
       } catch (refreshError) {
-        // refresh도 실패하면 로그아웃 처리
+        processQueue(refreshError);
+        // refresh 실패 시 로그아웃 처리
         if (typeof window !== 'undefined') {
           window.location.href = '/auth/login';
         }
         return Promise.reject(refreshError);
+      } finally {
+        setIsRefreshing(false);
       }
     }
     // refresh 상황이 아닌 경우
@@ -55,25 +72,3 @@ export const PopoCdnAxios = axios.create({
 export const InPoStackAxios = axios.create({
   baseURL: 'https://api.inpostack.poapper.club',
 });
-
-// refresh 토큰 요청 함수
-export const refreshAccessToken = async () => {
-  try {
-    const response = await fetch(`${popoApiUrl}/auth/refresh`, {
-      method: 'POST',
-      credentials: 'include', // 쿠키 포함
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-
-    if (!response.ok) {
-      throw new Error('Refresh token failed');
-    }
-
-    return true;
-  } catch (error) {
-    console.error('Refresh token error:', error);
-    throw error;
-  }
-};

--- a/lib/axios.instance.ts
+++ b/lib/axios.instance.ts
@@ -15,6 +15,39 @@ export const PoPoAxios = axios.create({
   baseURL: popoApiUrl as string,
 });
 
+// 엑세스 토큰 만료 시 리프레시 후 재시도 로직
+PoPoAxios.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (
+      error.response?.status === 401 &&
+      // 백엔드에서 엑세스 토큰 만료 시 내려주는 에러 메시지
+      error.response?.data?.error === 'AccessTokenExpired' &&
+      // 동일 요청 재시도를 방지하기 위함
+      !originalRequest._retry
+    ) {
+      try {
+        // refresh 요청
+        await refreshAccessToken();
+
+        // 원래 요청 재시도
+        originalRequest._retry = true;
+        return PoPoAxios(originalRequest);
+      } catch (refreshError) {
+        // refresh도 실패하면 로그아웃 처리
+        if (typeof window !== 'undefined') {
+          window.location.href = '/auth/login';
+        }
+        return Promise.reject(refreshError);
+      }
+    }
+    // refresh 상황이 아닌 경우
+    return Promise.reject(error);
+  },
+);
+
 export const PopoCdnAxios = axios.create({
   baseURL: 'https://cdn.popo.poapper.club',
 });
@@ -22,3 +55,25 @@ export const PopoCdnAxios = axios.create({
 export const InPoStackAxios = axios.create({
   baseURL: 'https://api.inpostack.poapper.club',
 });
+
+// refresh 토큰 요청 함수
+export const refreshAccessToken = async () => {
+  try {
+    const response = await fetch(`${popoApiUrl}/auth/refresh`, {
+      method: 'POST',
+      credentials: 'include', // 쿠키 포함
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('Refresh token failed');
+    }
+
+    return true;
+  } catch (error) {
+    console.error('Refresh token error:', error);
+    throw error;
+  }
+};

--- a/lib/refresh.utils.ts
+++ b/lib/refresh.utils.ts
@@ -1,0 +1,53 @@
+// refresh 관련 유틸리티 및 상태 관리
+import { PoPoAxios } from './axios.instance';
+
+let isRefreshing = false;
+// 여러 컴포넌트가 동시에 리프레시 토큰 재발급을 요청하는 것을 막기 위해 사용
+// 여러 컴포넌트가 각각 리프레시를 요청하면 백엔드에서 race condition으로 인해 오류가 발생할 수 있음
+// 이를 방지하기 위해 한 번의 리프레시로 모든 컴포넌트의 요청을 처리하도록 함
+let failedQueue: Array<{
+  resolve: (value?: any) => void;
+  reject: (error: any) => void;
+  originalRequest: any;
+}> = [];
+
+export const processQueue = (error: any) => {
+  failedQueue.forEach(({ resolve, reject, originalRequest }) => {
+    if (error) {
+      reject(error);
+    } else {
+      resolve(PoPoAxios(originalRequest));
+    }
+  });
+  failedQueue = [];
+};
+
+export const getIsRefreshing = () => isRefreshing;
+export const setIsRefreshing = (value: boolean) => {
+  isRefreshing = value;
+};
+
+export const addToFailedQueue = (
+  resolve: (value?: any) => void,
+  reject: (error: any) => void,
+  originalRequest: any,
+) => {
+  failedQueue.push({ resolve, reject, originalRequest });
+};
+
+export const refreshAccessToken = async () => {
+  try {
+    const response = await PoPoAxios.post(
+      '/auth/refresh',
+      {},
+      { withCredentials: true },
+    );
+    if (response.status !== 200 && response.status !== 201) {
+      throw new Error('Refresh token failed');
+    }
+    return true;
+  } catch (error) {
+    console.error('Refresh token error:', error);
+    throw error;
+  }
+};

--- a/lib/refresh.utils.ts
+++ b/lib/refresh.utils.ts
@@ -6,7 +6,9 @@ let isRefreshing = false;
 // 여러 컴포넌트가 각각 리프레시를 요청하면 백엔드에서 race condition으로 인해 오류가 발생할 수 있음
 // 이를 방지하기 위해 한 번의 리프레시로 모든 컴포넌트의 요청을 처리하도록 함
 let failedQueue: Array<{
+  // eslint-disable-next-line
   resolve: (value?: any) => void;
+  // eslint-disable-next-line
   reject: (error: any) => void;
   originalRequest: any;
 }> = [];
@@ -28,7 +30,9 @@ export const setIsRefreshing = (value: boolean) => {
 };
 
 export const addToFailedQueue = (
+  // eslint-disable-next-line
   resolve: (value?: any) => void,
+  // eslint-disable-next-line
   reject: (error: any) => void,
   originalRequest: any,
 ) => {


### PR DESCRIPTION
[리프레시 토큰 도입 이슈](https://github.com/PoApper/popo-nest-api/issues/134)에 따라 백엔드에 구현한 리프레시 토큰을 프론트에서 이용할 수 있게 했습니다
1. Access Token 자동 갱신
- 서버에서 401, AccessTokenExpired 에러가 오면
- `/auth/refresh` 로 토큰을 갱신한 뒤
-  실패했던 API 요청을 한 번만 재시도합니다.

2. 동시 Refresh 충돌 방지
- 아래 사진처럼 페이지 이동 시 한 컴포넌트가 아니라 여러 컴포넌트들(nav, footer 등등)이 서버로 요청을 보냅니다.
<img width="126" alt="image" src="https://github.com/user-attachments/assets/fed33c8e-e9e5-488d-862b-43aac94499fe" />   

- 여러 컴포넌트가 동시에 같은 Refresh Token으로 갱신 요청을 보내면 리프레시 토큰 순환(rotation) 로직 때문에 뒤늦은 요청이 실패하는 문제가 생깁니다.
- 이를 막기 위해 전역 Refresh 큐를 도입하여 갱신이 진행 중이면 새 요청을 모두 큐에 보관하고,
- 최초 갱신이 끝난 뒤 한꺼번에 처리하게 변경했습니다.


### 여러 컴포넌트가 리프레시 요청을 할 때 순차 다이어그램
<img width="938" alt="image" src="https://github.com/user-attachments/assets/d000d900-15a3-4b96-8e37-9ffc8afe94cb" />
