### PR TITLE
feat: added association category indicator, sort by category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ yarn-error.log*
 
 # NextJS HTTPS
 certificates/*.pem
+/.ai/mcp/mcp.json

--- a/pages/association/index.tsx
+++ b/pages/association/index.tsx
@@ -5,30 +5,72 @@ import { Image } from 'semantic-ui-react';
 
 import Layout from '@/components/layout';
 import { PoPoAxios } from '@/lib/axios.instance';
-import { IAssociationIntroduce } from '@/types/introduce.interface';
+import {
+  IAssociationIntroduce,
+  IAssociationCategory,
+} from '@/types/introduce.interface';
+
+interface IGroupedAssociation {
+  category: IAssociationCategory;
+  associations: IAssociationIntroduce[];
+}
 
 const AssociationIndexPage: React.FunctionComponent<{
   associationList: IAssociationIntroduce[];
 }> = ({ associationList }) => {
+  // 카테고리 ID를 기준으로 그룹화
+  const groupedData = associationList.reduce(
+    (acc, item) => {
+      const catId = item.categoryId;
+      if (!acc[catId]) {
+        acc[catId] = {
+          category: item.category,
+          associations: [],
+        };
+      }
+      acc[catId].associations.push(item);
+      return acc;
+    },
+    {} as Record<number, IGroupedAssociation>,
+  );
+
+  // 카테고리 ID 순서대로 정렬하여 배열로 변환
+  const sortedCategories = Object.values(groupedData).sort(
+    (a, b) => a.category.id - b.category.id,
+  );
+
   return (
     <Layout>
-      <IntroduceGrid>
-        {associationList.map((intro) => (
-          <div key={intro.uuid}>
-            <Image
-              centered
-              size="small"
-              href={`/association/introduce/${intro.name}`}
-              src={
-                intro.imageUrl ??
-                'https://react.semantic-ui.com/images/wireframe/image.png'
-              }
-              alt={`${intro.name}_logo`}
-            />
-            <AssociationName>{intro.name}</AssociationName>
-          </div>
+      <PageContainer>
+        {sortedCategories.map((group) => (
+          <CategorySection key={group.category.id}>
+            <CategoryHeader>{group.category.displayName}</CategoryHeader>
+            <IntroduceGrid>
+              {group.associations.map((intro) => (
+                <div key={intro.uuid}>
+                  <Image
+                    centered
+                    size="small"
+                    href={`/association/introduce/${intro.name}`}
+                    src={
+                      intro.imageUrl ??
+                      'https://react.semantic-ui.com/images/wireframe/image.png'
+                    }
+                    alt={`${intro.name}_logo`}
+                    style={{
+                      width: '150px',
+                      height: '150px',
+                      objectFit: 'cover',
+                      objectPosition: 'center',
+                    }}
+                  />
+                  <AssociationName>{intro.name}</AssociationName>
+                </div>
+              ))}
+            </IntroduceGrid>
+          </CategorySection>
         ))}
-      </IntroduceGrid>
+      </PageContainer>
     </Layout>
   );
 };
@@ -36,15 +78,42 @@ const AssociationIndexPage: React.FunctionComponent<{
 export default AssociationIndexPage;
 
 export const getServerSideProps: GetServerSideProps = async () => {
-  const res = await PoPoAxios.get<IAssociationIntroduce[]>(
-    'introduce/association',
-  );
-  const associationList = res.data;
+  try {
+    const res = await PoPoAxios.get<IAssociationIntroduce[]>(
+      'introduce/association',
+    );
+    const associationList = res.data;
 
-  return {
-    props: { associationList },
-  };
+    return {
+      props: { associationList },
+    };
+  } catch (e) {
+    return {
+      props: { associationList: [] },
+    };
+  }
 };
+
+const PageContainer = styled.div`
+  padding: 2rem 0;
+`;
+
+const CategorySection = styled.section`
+  margin-bottom: 4rem;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+const CategoryHeader = styled.h2`
+  font-size: 2rem;
+  font-weight: bold;
+  margin-bottom: 2rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid #eee;
+  color: #333;
+`;
 
 const IntroduceGrid = styled.div`
   display: grid;

--- a/pages/association/index.tsx
+++ b/pages/association/index.tsx
@@ -6,71 +6,128 @@ import { Image } from 'semantic-ui-react';
 import Layout from '@/components/layout';
 import { PoPoAxios } from '@/lib/axios.instance';
 import {
+  AssociationType,
   IAssociationIntroduce,
-  IAssociationCategory,
 } from '@/types/introduce.interface';
 
+type AssociationTypeKey = 'executive' | 'autonomous' | 'media' | 'specialized';
+
 interface IGroupedAssociation {
-  category: IAssociationCategory;
+  associationType: AssociationTypeKey | 'uncategorized';
+  displayName: string;
   associations: IAssociationIntroduce[];
 }
+
+const associationTypeOrder: AssociationTypeKey[] = [
+  'executive',
+  'autonomous',
+  'media',
+  'specialized',
+];
+
+const associationTypeDisplayName: Record<AssociationTypeKey, string> = {
+  executive: '집행기구',
+  autonomous: '자치기구',
+  media: '언론기구',
+  specialized: '전문기구',
+};
+
+const associationTypeMap: Record<AssociationType, AssociationTypeKey> = {
+  executive: 'executive',
+  autonomous: 'autonomous',
+  media: 'media',
+  specialized: 'specialized',
+  집행기구: 'executive',
+  자치기구: 'autonomous',
+  언론기구: 'media',
+  전문기구: 'specialized',
+};
+
+const getAssociationType = (
+  associationType?: IAssociationIntroduce['associationType'],
+): AssociationTypeKey | null => {
+  if (!associationType) {
+    return null;
+  }
+
+  return associationTypeMap[associationType] ?? null;
+};
 
 const AssociationIndexPage: React.FunctionComponent<{
   associationList: IAssociationIntroduce[];
 }> = ({ associationList }) => {
-  // 카테고리 ID를 기준으로 그룹화
-  const groupedData = associationList.reduce(
+  // 자치단체 분류를 기준으로 그룹화
+  const groupedData = associationList.reduce<
+    Record<AssociationTypeKey | 'uncategorized', IGroupedAssociation>
+  >(
     (acc, item) => {
-      const catId = item.categoryId;
-      if (!acc[catId]) {
-        acc[catId] = {
-          category: item.category,
+      const associationType = getAssociationType(item.associationType);
+      const key = associationType ?? 'uncategorized';
+
+      if (!acc[key]) {
+        acc[key] = {
+          associationType: key,
+          displayName: associationType
+            ? associationTypeDisplayName[associationType]
+            : '미분류',
           associations: [],
         };
       }
-      acc[catId].associations.push(item);
+
+      acc[key].associations.push(item);
       return acc;
     },
-    {} as Record<number, IGroupedAssociation>,
+    {} as Record<AssociationTypeKey | 'uncategorized', IGroupedAssociation>,
   );
 
-  // 카테고리 ID 순서대로 정렬하여 배열로 변환
-  const sortedCategories = Object.values(groupedData).sort(
-    (a, b) => a.category.id - b.category.id,
-  );
+  // 원하는 순서대로 정렬하여 배열로 변환
+  const sortedCategories = associationTypeOrder
+    .map((associationType) => groupedData[associationType])
+    .filter((category): category is IGroupedAssociation => Boolean(category));
+
+  if (groupedData.uncategorized && sortedCategories.length > 0) {
+    sortedCategories.push(groupedData.uncategorized);
+  }
+
+  const introduceItems = (associationItems: IAssociationIntroduce[]) =>
+    associationItems.map((intro) => (
+      <div key={intro.uuid}>
+        <Image
+          centered
+          size="small"
+          href={`/association/introduce/${intro.name}`}
+          src={
+            intro.imageUrl ??
+            'https://react.semantic-ui.com/images/wireframe/image.png'
+          }
+          alt={`${intro.name}_logo`}
+          style={{
+            width: '150px',
+            height: '150px',
+            objectFit: 'cover',
+            objectPosition: 'center',
+          }}
+        />
+        <AssociationName>{intro.name}</AssociationName>
+      </div>
+    ));
 
   return (
     <Layout>
-      <PageContainer>
-        {sortedCategories.map((group) => (
-          <CategorySection key={group.category.id}>
-            <CategoryHeader>{group.category.displayName}</CategoryHeader>
-            <IntroduceGrid>
-              {group.associations.map((intro) => (
-                <div key={intro.uuid}>
-                  <Image
-                    centered
-                    size="small"
-                    href={`/association/introduce/${intro.name}`}
-                    src={
-                      intro.imageUrl ??
-                      'https://react.semantic-ui.com/images/wireframe/image.png'
-                    }
-                    alt={`${intro.name}_logo`}
-                    style={{
-                      width: '150px',
-                      height: '150px',
-                      objectFit: 'cover',
-                      objectPosition: 'center',
-                    }}
-                  />
-                  <AssociationName>{intro.name}</AssociationName>
-                </div>
-              ))}
-            </IntroduceGrid>
-          </CategorySection>
-        ))}
-      </PageContainer>
+      {sortedCategories.length > 0 ? (
+        <PageContainer>
+          {sortedCategories.map((category) => (
+            <CategorySection key={category.associationType}>
+              <CategoryHeader>{category.displayName}</CategoryHeader>
+              <IntroduceGrid>
+                {introduceItems(category.associations)}
+              </IntroduceGrid>
+            </CategorySection>
+          ))}
+        </PageContainer>
+      ) : (
+        <IntroduceGrid>{introduceItems(associationList)}</IntroduceGrid>
+      )}
     </Layout>
   );
 };
@@ -87,7 +144,7 @@ export const getServerSideProps: GetServerSideProps = async () => {
     return {
       props: { associationList },
     };
-  } catch (e) {
+  } catch {
     return {
       props: { associationList: [] },
     };

--- a/types/introduce.interface.ts
+++ b/types/introduce.interface.ts
@@ -19,6 +19,12 @@ export interface IClubIntroduce {
   youtubeUrl?: string;
 }
 
+export interface IAssociationCategory {
+  id: number;
+  name: string;
+  displayName: string;
+}
+
 export interface IAssociationIntroduce {
   uuid: string;
   name: string;
@@ -31,4 +37,6 @@ export interface IAssociationIntroduce {
   facebookUrl?: string;
   instagramUrl?: string;
   youtubeUrl?: string;
+  category: IAssociationCategory;
+  categoryId: number;
 }

--- a/types/introduce.interface.ts
+++ b/types/introduce.interface.ts
@@ -19,11 +19,15 @@ export interface IClubIntroduce {
   youtubeUrl?: string;
 }
 
-export interface IAssociationCategory {
-  id: number;
-  name: string;
-  displayName: string;
-}
+export type AssociationType =
+  | 'executive'
+  | 'autonomous'
+  | 'media'
+  | 'specialized'
+  | '집행기구'
+  | '자치기구'
+  | '언론기구'
+  | '전문기구';
 
 export interface IAssociationIntroduce {
   uuid: string;
@@ -37,6 +41,5 @@ export interface IAssociationIntroduce {
   facebookUrl?: string;
   instagramUrl?: string;
   youtubeUrl?: string;
-  category: IAssociationCategory;
-  categoryId: number;
+  associationType?: AssociationType | '' | null;
 }


### PR DESCRIPTION
Frontend Part of #168 
# DO NOT MERGE BEFORE BACKEND 

## Preview
<img width="820" height="897" alt="image" src="https://github.com/user-attachments/assets/55c21816-b0e1-4c7d-913b-9c82ce694c09" />


## Backend TO-DO

@yojun313 
제가 로컬에서 돌아가도록 만든 예시 코드를 popo-nest-api에 [브랜치](https://github.com/PoApper/popo-nest-api/commit/d6dd458d182c9f74e9662edfcb270e4deb80b58b)를 하나 파서 올려 두었습니다. 참고하면 좋을 것 같아요

### "intro_association_category" 테이블
<img width="393" height="202" alt="image" src="https://github.com/user-attachments/assets/70b8c045-1179-47df-890b-ed737bab681d" />

테이블 생성 명령어

```
CREATE TABLE `intro_association_category` (
	`id` INT(11) NOT NULL AUTO_INCREMENT,
	`name` VARCHAR(255) NOT NULL COLLATE 'utf8mb4_uca1400_ai_ci',
	`displayName` VARCHAR(255) NOT NULL COLLATE 'utf8mb4_uca1400_ai_ci',
	PRIMARY KEY (`id`) USING BTREE,
	UNIQUE INDEX `IDX_b65d1603bfc5f82f2fbc6c27f6` (`name`) USING BTREE
)
COLLATE='utf8mb4_uca1400_ai_ci'
ENGINE=InnoDB
AUTO_INCREMENT=5
;

```
### "intro_association" 테이블 변경 사항

column ```category_id``` 추가

intro_association_category 테이블의 category_id를 Foreign Key로 가짐.

값: 1,2,3,4중 하나!
