### PR TITLE
CI: 워크플로우 트리거를 다른 저장소와 통일

### DIFF
--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -1,11 +1,23 @@
 on:
   push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  release:
+    types: [published]
 
 name: Docker Build and Push
 
 env:
   ECR_REGISTRY: 151345152001.dkr.ecr.ap-northeast-2.amazonaws.com
   ECR_REPOSITORY: popo-public-web
+
+# 같은 PR 안에서는 가장 최근 push만 워크플로우를 실행하도록 설정
+concurrency:
+  group: ${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -36,6 +48,10 @@ jobs:
     name: Docker build and push
     needs: lint
     runs-on: ubuntu-24.04-arm
+    # docker_build_and_push 잡은 모든 워크플로우에서 유일하게 하나만 실행되도록 설정
+    concurrency:
+      group: docker-build
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,9 +71,9 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
       - name: Determine Prod/Dev Stage
         run: |
-          if [[ ${{ github.ref_type }} == 'tag' ]]; then
+          if [[ ${{ github.event_name }} == 'release' ]]; then
             echo "PROD"
-            echo "IMAGE_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "IMAGE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
             echo "NEXT_PUBLIC_ENV=prod" >> $GITHUB_ENV
           else
             echo "DEV"
@@ -81,6 +97,9 @@ jobs:
   redeploy_dev_service:
     name: Redeploy Dev Service
     needs: docker_build_and_push
+    # release(=Prod 이미지 빌드) 때는 dev를 건드리지 않는다.
+    # Prod 배포는 Portainer에서 이미지 태그를 직접 바꿔주는 수동 절차다.
+    if: github.event_name != 'release'
     runs-on: ubuntu-latest
     steps:
       - name: Redeploy Dev Service


### PR DESCRIPTION
## 문제

이 저장소의 워크플로우만 트리거가 `on: push:` 하나뿐이고 브랜치 필터가 없습니다. 나머지 두 저장소(`popo-nest-api`, `popo-admin-web`)는 `push`/`pull_request`를 `main`으로 제한하고 `release`를 따로 받습니다.

그래서 실제로 이런 일이 일어납니다.

- **아무 feature 브랜치나 push하면 그 즉시 dev 서버가 그 코드로 바뀝니다.** 다른 사람이 dev에서 검증하는 중이어도 덮어씁니다. 실험용 브랜치 하나 올려보는 것과 dev 배포가 구분되지 않습니다.
- prod 이미지 판별을 `github.ref_type == 'tag'`로 합니다. 결과는 대체로 같지만(릴리즈를 만들면 태그도 push되니까) 다른 두 저장소와 조건이 달라서, 워크플로우를 읽는 사람이 매번 확인해야 합니다.
- `concurrency` 설정이 없어 같은 브랜치에 연달아 push하면 빌드가 겹칩니다. 다른 두 저장소에는 있습니다.

## 바꾸는 것

세 저장소의 워크플로우를 같은 모양으로 맞춥니다.

| | 이전 | 이후 |
| :--- | :--- | :--- |
| 트리거 | `push` (전체 브랜치) | `push`/`pull_request` → `main`, `release: published` |
| prod 판별 | `github.ref_type == 'tag'` | `github.event_name == 'release'` |
| 이미지 태그 | `github.ref_name` | `github.event.release.tag_name` |
| concurrency | 없음 | 브랜치별 취소 + `docker-build` 단일 실행 |

`redeploy_dev_service`에 `if: github.event_name != 'release'`도 추가합니다. 릴리즈는 prod 이미지를 만드는 동작인데 그때마다 dev Portainer 웹훅까지 때리고 있었습니다. dev는 `latest` 태그라 내용이 바뀌지는 않지만, 릴리즈 로그만 보면 dev가 재배포된 것처럼 보여 혼란스럽습니다. (같은 수정을 나머지 두 저장소에도 올렸습니다: PoApper/popo-nest-api#215, PoApper/popo-admin-web#150)

## 영향

**dev 배포 방식이 바뀝니다.** 이제 feature 브랜치 push만으로는 dev에 나가지 않고, **main 대상 PR을 열거나 main에 push할 때** 나갑니다. 나머지 두 저장소와 같은 흐름이라 익숙해지는 데 문제는 없을 것으로 봅니다. 다만 지금까지 "push하면 dev에서 확인"하던 습관이 있다면 PR을 먼저 여는 방식으로 바뀝니다.

되돌리고 싶다면 트리거 블록만 원복하면 됩니다.

## 검증

로컬에서 확인할 수 있는 범위는 YAML 파싱까지입니다(세 파일 모두 통과). 실제 동작은 머지 후 첫 실행에서 봐야 합니다. 머지 후 확인할 것:

- feature 브랜치에 push → Actions가 **돌지 않아야** 함
- main 대상 PR → Actions가 돌고 dev 배포까지 진행
- 릴리즈 publish → prod 태그 이미지가 ECR에 올라가고 `Redeploy Dev Service`는 **skip**
